### PR TITLE
Update unit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,9 @@
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {
-        "psr-4": {
-            "Pantheon\\EI\\": "/inc/namespace.php"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Tests\\": "tests/"
-        }
+        "files": [
+            "inc/namespace.php"
+        ]
     },
     "scripts": {
         "lint": "vendor/bin/phpcs -s --standard=phpcs.ruleset.xml .",

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -17,6 +17,6 @@ class testsBase extends TestCase {
 	 * Make sure unit tests are running.
 	 */
 	public function testPHPUnitIsWorking() {
-		$this->assertTrue( true );
+		$this->assertTrue( function_exists( '\\Pantheon\\EI\\bootstrap' ) );
 	}
 }


### PR DESCRIPTION
* Switches the initial unit test from just an example to something that actually does something.
* Updates the composer autoloading to use file autoloading instead of PSR-4. This is somewhat more intuitive and gives us more control and options if multiple namespaces exist in the same directory (which might be the case in /inc
* Removes the `autoload-dev` param in composer at all. This was only being used to PSR-4 autoload `\\Tests` which isn't how they're called at all and isn't used or necessary.