### PR TITLE
Update the plugin loader

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -11,4 +11,9 @@
 
 namespace Pantheon\EI;
 
+// If the bootstrap function does not exist, we're probably not using the Composer autoloader, so require that first.
+if ( ! function_exists( __NAMESPACE__ . '\\bootstrap' ) ) {
+	require_once __DIR__ . '/vendor/autoload.php';
+}
+
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\bootstrap', 0 );

--- a/plugin.php
+++ b/plugin.php
@@ -9,9 +9,6 @@
  * @package Pantheon/EdgeIntegrations
  */
 
-/**
- * Include the namespace
- */
-require_once __DIR__ . '/inc/namespace.php';
+namespace Pantheon\EI;
 
 add_action( 'plugins_loaded', 'Pantheon\EI\\bootstrap', 0 );

--- a/plugin.php
+++ b/plugin.php
@@ -11,9 +11,4 @@
 
 namespace Pantheon\EI;
 
-// If the bootstrap function does not exist, we're probably not using the Composer autoloader, so require that first.
-if ( ! function_exists( __NAMESPACE__ . '\\bootstrap' ) ) {
-	require_once __DIR__ . '/vendor/autoload.php';
-}
-
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\bootstrap', 0 );

--- a/plugin.php
+++ b/plugin.php
@@ -11,4 +11,4 @@
 
 namespace Pantheon\EI;
 
-add_action( 'plugins_loaded', 'Pantheon\EI\\bootstrap', 0 );
+add_action( 'plugins_loaded', __NAMESPACE__ . '\\bootstrap', 0 );


### PR DESCRIPTION
A couple things I noticed in the main plugin file:

* We should declare the Pantheon\EI namespace. We might actually want to make a Pantheon\EI\WP namespace so we don't clash with the Pantheon\EI namespace in the Edge Integrations library, but maybe we burn that bridge when we get to it.
* We shouldn't need to manually require `inc/namespace.php` -- that should be loaded by the Composer autoloader (it just wasn't working with the way I set up the PSR-4 autoloading).

I went back and forth trying to decide if it was worth it to require `vendor/autoload.php` manually if the autoloader wasn't working for some reason. I ultimately decided that as long as this plugin is installed via Composer, that would never be an issue, as the autoloader would trickle down to the root Composer autoloader, and currently we're only supporting Composer installs. 

For a WordPress plugin repository implementation, we'd likely need to rethink this anyway -- possibly by not gitignoring the vendor/ directory, because there might be stuff there that we need. That's a future us (or me) problem, though, and right now I think that simpler is better.