### PR TITLE
[EI-27] Maybe manually load the Composer autoload file 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,9 @@
         ]
     },
     "scripts": {
-        "lint": "vendor/bin/phpcs -s --standard=phpcs.ruleset.xml .",
+        "lint:php": "find ./plugin.php ./inc ./tests  -name '*.php' -exec php -l {} \\;",
+        "lint:phpcs": "vendor/bin/phpcs -s --standard=phpcs.ruleset.xml .",
+        "lint": "composer lint:php && composer lint:phpcs",
         "test:unit": "vendor/bin/phpunit -c phpunit.xml",
         "test": "composer test:unit"
     },

--- a/plugin.php
+++ b/plugin.php
@@ -11,4 +11,9 @@
 
 namespace Pantheon\EI\WP;
 
+// Check if the bootstrap function exists. If it doesn't, it means we're not using the Composer autoloader.
+if ( ! function_exists( __NAMESPACE__ . '\\bootstrap' ) ) {
+	require_once __DIR__ . '/vendor/autoload.php';
+}
+
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\bootstrap', 0 );


### PR DESCRIPTION
Check if `\Pantheon\EI\WP\bootstrap()` exists. If it doesn't exist, we didn't autoload `inc/namespace.php` which means the Composer autoloader isn't being used. In that case, load `vendor/autoload.php`. 

We want to use the Composer autoloader because we _also_ need it for the `pantheon-edge-integrations` global library.

Also, this PR adds a syntax checking script and includes that in `composer lint`