### PR TITLE
[EI-18] geo hooks

### DIFF
--- a/inc/geo.php
+++ b/inc/geo.php
@@ -11,6 +11,8 @@ use Pantheon\EI;
 
 /**
  * Kick off our namespace.
+ *
+ * @TODO: Validate that we still actually need a bootstrap (we might not).
  */
 function bootstrap() {
 	// Helper variable function that simplifies callbacks.

--- a/inc/geo.php
+++ b/inc/geo.php
@@ -80,4 +80,12 @@ function get_geo( string $data_type = '', $data = null ) : string {
 	 * @param mixed Data passed to the HeaderData class. By default, this is pulled from $_SERVER data.
 	 */
 	do_action( 'pantheon.ei.get_geo', $parsed_geo[ $data_type ], $data_type, $data );
+
+	/**
+	 * Allow developers to modify the requested geo data. This filter fires after the data is parsed and before it is returned making this the last stop before data is output.
+	 *
+	 * @hook pantheon.ei.geo_data
+	 * @param string The requested geo data.
+	 */
+	return apply_filters( 'pantheon.ei.get_geo', $parsed_geo[ $data_type ] );
 }

--- a/inc/geo.php
+++ b/inc/geo.php
@@ -69,5 +69,15 @@ function get_geo( string $data_type = '', $data = null ) : string {
 		$parsed_geo['latlon'] = $parsed_geo['lat'] . ',' . $parsed_geo['lon'];
 	}
 
-	return $parsed_geo[ $data_type ];
+	/**
+	 * Fires after the geo data is retrieved but before it is returned.
+	 *
+	 * Allows developers to hook into the geo data retrieval process and access the geo value and the type of data requested and the full passed data, if it exists.
+	 *
+	 * @hook pantheon.ei.get_geo
+	 * @param string The geo data value.
+	 * @param string The type of geo data requested.
+	 * @param mixed Data passed to the HeaderData class. By default, this is pulled from $_SERVER data.
+	 */
+	do_action( 'pantheon.ei.get_geo', $parsed_geo[ $data_type ], $data_type, $data );
 }

--- a/inc/geo.php
+++ b/inc/geo.php
@@ -33,16 +33,8 @@ function bootstrap() {
  * @return string The requested geo data.
  */
 function get_geo( string $data_type = '', $data = null ) : string {
-	/**
-	 * Allow developers to modify the allowed geo data types.
-	 *
-	 * @hook pantheon.ei.geo_data_types
-	 * @param array The allowed geo data types.
-	 */
-	$allowed_values = apply_filters( 'pantheon.ei.geo_allowed_values', [ '', 'geo', 'country', 'region', 'city', 'postal-code', 'lat', 'lon', 'latlon' ] );
-
 	// If the passed data type is not allowed, return an empty string.
-	if ( ! in_array( $data_type, $allowed_values, true ) ) {
+	if ( ! in_array( $data_type, get_geo_allowed_values(), true ) ) {
 		return '';
 	}
 
@@ -88,4 +80,19 @@ function get_geo( string $data_type = '', $data = null ) : string {
 	 * @param string The requested geo data.
 	 */
 	return apply_filters( 'pantheon.ei.get_geo', $parsed_geo[ $data_type ] );
+}
+
+/**
+ * Returns the array of allowed geo data types.
+ *
+ * @return array
+ */
+function get_geo_allowed_values() : array {
+	/**
+	 * Allow developers to modify the allowed geo data types.
+	 *
+	 * @hook pantheon.ei.geo_data_types
+	 * @param array The allowed geo data types.
+	 */
+	return apply_filters( 'pantheon.ei.geo_allowed_values', [ '', 'geo', 'country', 'region', 'city', 'postal-code', 'lat', 'lon', 'latlon' ] );
 }

--- a/inc/geo.php
+++ b/inc/geo.php
@@ -51,7 +51,7 @@ function get_geo( string $data_type = '', $data = null ) : string {
 
 	// If 'latlon' was requested, return the latitude and longitude.
 	if ( $data_type === 'latlon' ) {
-		return $parsed_geo['lat'] . ',' . $parsed_geo['lon'];
+		$parsed_geo['latlon'] = $parsed_geo['lat'] . ',' . $parsed_geo['lon'];
 	}
 
 	return $parsed_geo[ $data_type ];

--- a/inc/geo.php
+++ b/inc/geo.php
@@ -35,6 +35,7 @@ function bootstrap() {
 function get_geo( string $data_type = '', $data = null ) : string {
 	$allowed_values = [ '', 'geo', 'country', 'region', 'city', 'postal-code', 'lat', 'lon', 'latlon' ];
 
+	// If the passed data type is not allowed, return an empty string.
 	if ( ! in_array( $data_type, $allowed_values, true ) ) {
 		return '';
 	}

--- a/inc/geo.php
+++ b/inc/geo.php
@@ -71,7 +71,7 @@ function get_geo( string $data_type = '', $data = null ) : string {
 	 * @param string The type of geo data requested.
 	 * @param mixed Data passed to the HeaderData class. By default, this is pulled from $_SERVER data.
 	 */
-	do_action( 'pantheon.ei.get_geo', $parsed_geo[ $data_type ], $data_type, $data );
+	do_action( 'pantheon.ei.before_get_geo', $parsed_geo[ $data_type ], $data_type, $data );
 
 	/**
 	 * Allow developers to modify the requested geo data. This filter fires after the data is parsed and before it is returned making this the last stop before data is output.

--- a/inc/geo.php
+++ b/inc/geo.php
@@ -46,7 +46,15 @@ function get_geo( string $data_type = '', $data = null ) : string {
 		return '';
 	}
 
-	$parsed_geo = EI\HeaderData::parse( 'Audience', $data );
+	/**
+	 * Get the geo data from the HeaderData class and allow it to be filtered.
+	 *
+	 * For filtering purposes, the data passed is an array of key/value pairs of geo data. Because this filter fires after the data types are checked, it's possible (but not recommended) to provide data that would otherwise be filtered out.
+	 *
+	 * @hook pantheon.ei.geo_data
+	 * @param array The full, parsed Audience geo data as an array.
+	 */
+	$parsed_geo = apply_filters( 'pantheon.ei.parsed_geo_data', EI\HeaderData::parse( 'Audience', $data ) );
 
 	// If no geo data type was passed, return all Audience data.
 	if ( empty( $data_type ) ) {

--- a/inc/geo.php
+++ b/inc/geo.php
@@ -33,7 +33,13 @@ function bootstrap() {
  * @return string The requested geo data.
  */
 function get_geo( string $data_type = '', $data = null ) : string {
-	$allowed_values = [ '', 'geo', 'country', 'region', 'city', 'postal-code', 'lat', 'lon', 'latlon' ];
+	/**
+	 * Allow developers to modify the allowed geo data types.
+	 *
+	 * @hook pantheon.ei.geo_data_types
+	 * @param array The allowed geo data types.
+	 */
+	$allowed_values = apply_filters( 'pantheon.ei.geo_allowed_values', [ '', 'geo', 'country', 'region', 'city', 'postal-code', 'lat', 'lon', 'latlon' ] );
 
 	// If the passed data type is not allowed, return an empty string.
 	if ( ! in_array( $data_type, $allowed_values, true ) ) {

--- a/tests/geoTest.php
+++ b/tests/geoTest.php
@@ -9,6 +9,8 @@ use Pantheon\EI;
 use Pantheon\EI\WP\Geo;
 use PHPUnit\Framework\TestCase;
 
+use function Pantheon\EI\WP\Geo\get_geo_allowed_values;
+
 /**
  * Main test class for WordPress Edge Integrations plugin.
  */
@@ -211,5 +213,38 @@ class geoTests extends TestCase {
 				'geo:UK' => [ 'HTTP_AUDIENCE' => 'geo:UK|city:London|postal-code:WC2N 5EJ|region:England|lat:51.5074|lon:-0.1278' ]
 			],
 		];
+	}
+
+	/**
+	 * Test the pantheon.ei.geo_allowed_values filter and get_geo_allowed_values function.
+	 */
+	public function testGeoAllowedValues() {
+		$allowed_values = get_geo_allowed_values();
+		$this->assertIsArray( $allowed_values );
+		$this->assertNotEmpty( $allowed_values );
+		$this->assertEquals(
+			$allowed_values,
+			[
+				'',
+				'geo',
+				'country',
+				'region',
+				'city',
+				'postal-code',
+				'lat',
+				'lon',
+				'latlon',
+			],
+			'Allowed values do not match'
+		);
+
+		// Add a new value to the allowed values.
+		add_filter( 'pantheon.ei.geo_allowed_values', function( $values ) {
+			$values[] = 'some-other-value';
+			return $values;
+		}, 10, 1 );
+
+		// Validate that the new value is in the allowed values.
+		$this->assertContains( 'some-other-value', get_geo_allowed_values() );
 	}
 }

--- a/tests/geoTest.php
+++ b/tests/geoTest.php
@@ -275,6 +275,11 @@ class geoTests extends TestCase {
 			] ),
 			'Parsed data does not match'
 		);
+
+		// Reset the geo data to something resembling real data. This is a hack because data is retained across tests.
+		add_filter( 'pantheon.ei.parsed_geo_data', function() {
+			return EI\HeaderData::parse( 'Audience', $this->mockAudienceData()[0]['geo:US'] );
+		}, 10 );
 	}
 
 	/**

--- a/tests/geoTest.php
+++ b/tests/geoTest.php
@@ -247,4 +247,33 @@ class geoTests extends TestCase {
 		// Validate that the new value is in the allowed values.
 		$this->assertContains( 'some-other-value', get_geo_allowed_values() );
 	}
+
+	/**
+	 * Test the pantheon.ei.parsed_geo_data filter.
+	 */
+	public function testParsedGeoData() {
+		// Filter the parsed geo data.
+		add_filter( 'pantheon.ei.parsed_geo_data', function( $geo_data ) {
+			return [
+				'name' => 'Chris Reynolds',
+				'role' => 'Software Engineer',
+				'team' => 'CMS Ecosystems',
+				'email' => 'me@someemaildomainthatdoesnotexist.io',
+			];
+		}, 10, 1 );
+
+		// Get geo with no parameters. Should return all geo data in JSON. Since we're filtering it, it should return the arbitrary data we passed.
+		$data = Geo\get_geo();
+		$this->assertJson( $data );
+		$this->assertEquals(
+			$data,
+			json_encode( [
+				'name' => 'Chris Reynolds',
+				'role' => 'Software Engineer',
+				'team' => 'CMS Ecosystems',
+				'email' => 'me@someemaildomainthatdoesnotexist.io',
+			] ),
+			'Parsed data does not match'
+		);
+	}
 }

--- a/tests/geoTest.php
+++ b/tests/geoTest.php
@@ -276,4 +276,12 @@ class geoTests extends TestCase {
 			'Parsed data does not match'
 		);
 	}
+
+	/**
+	 * Test that the pantheon.ei.get_geo action hook fires.
+	 */
+	public function testGetGeoAction() {
+		Geo\get_geo();
+		$this->assertGreaterThan( 0, did_action( 'pantheon.ei.get_geo' ) );
+	}
 }

--- a/tests/geoTest.php
+++ b/tests/geoTest.php
@@ -287,6 +287,7 @@ class geoTests extends TestCase {
 	 */
 	public function testGetGeoAction() {
 		Geo\get_geo();
-		$this->assertGreaterThan( 0, did_action( 'pantheon.ei.get_geo' ) );
+		$this->assertGreaterThan( 0, did_action( 'pantheon.ei.before_get_geo' ) );
+	}
 	}
 }

--- a/tests/geoTest.php
+++ b/tests/geoTest.php
@@ -289,5 +289,20 @@ class geoTests extends TestCase {
 		Geo\get_geo();
 		$this->assertGreaterThan( 0, did_action( 'pantheon.ei.before_get_geo' ) );
 	}
+
+	/**
+	 * Test the pantheon.ei.get_geo filter.
+	 */
+	public function testGetGeoFilter() {
+		// Filter the geo data.
+		add_filter( 'pantheon.ei.get_geo', function( $value ) {
+			return 'Antarctica';
+		}, 10, 1 );
+
+		$this->assertEquals(
+			Geo\get_geo( 'country' ),
+			'Antarctica',
+			'Filtered geo data does not match'
+		);
 	}
 }


### PR DESCRIPTION
This PR mostly handles adding filters and a hook inside `get_geo`. Geo allowed values are broken out into a separate, smaller function and the filter is moved into that function. Filters are all validated with discrete unit tests.