### PR TITLE
[EI-60] Alter actions for new release process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Pantheon WP EI Build
 on:
-  push:
+  pull_request:
     branches:
       - build
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: Install composer dependencies and run tests
+    name: Lint and Test
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,19 @@ on:
     branches:
       - build
 jobs:
-  build_and_tag:
+  test:
+    runs-on: ubuntu-latest
+    name: Install composer dependencies and run tests
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: composer install
+    - name: Run lint
+      run: composer lint
+    - name: Run unit tests
+      run: composer test
+  build:
+    needs: test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Pantheon WP EI Build
+on:
+  push:
+    branches:
+      - build
+jobs:
+  build_and_tag:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Compile assets
+      run: |
+        npm install
+        npm run build
+    - name: Commit and push build files
+      run: |
+        git config --local user.email "bot@getpantheon.com"
+        git config --local user.name "Pantheon Automation"
+        git add -f dist/
+        git commit -m "Built assets"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,12 @@ jobs:
     - uses: actions/checkout@v2
     - name: Compile assets
       run: |
+        composer install --no-dev -o
         npm install
         npm run build
     - name: Commit and push build files
       run: |
         git config --local user.email "bot@getpantheon.com"
         git config --local user.name "Pantheon Automation"
-        git add -f dist/
+        git add -f dist/ vendor/
         git commit -m "Built assets"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Pantheon WordPress Edge Integrations
+name: Pantheon WP EI Lint and Test
 on: push
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,17 +1,21 @@
 name: Pantheon WP EI Lint and Test
-on: push
+on:
+  push:
+    # This job is copied in build.yml so we can use the
+    # needs: test dependency on the build job.
+    # Cross workflow dependencies are not yet supported:
+    # https://github.community/t/how-do-i-specify-job-dependency-running-in-another-workflow/16482
+    branches-ignore:
+      - build
 jobs:
   test:
     runs-on: ubuntu-latest
     name: Install composer dependencies and run tests
     steps:
     - uses: actions/checkout@v2
-
     - name: Install dependencies
       run: composer install
-
     - name: Run lint
       run: composer lint
-
     - name: Run unit tests
       run: composer test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,45 +4,10 @@ on:
     tags:
       - '*'
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Compile assets
-      run: |
-        npm install
-        npm run build
-    - name: Remove node_modules
-      run: rm -rf node_modules
-    - name: Save plugin as artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: pantheon-wordpress-edge-integrations
-        path: ${{ github.workspace }}
-        if-no-files-found: error
   release:
-    needs: build
     runs-on: ubuntu-latest
     steps:
-    - name: Download plugin as artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: pantheon-wordpress-edge-integrations
-        path: pantheon-wordpress-edge-integrations
-    # Validate files.
-    - name: List Files
-      run: |
-        ls pantheon-wordpress-edge-integrations
-        ls pantheon-wordpress-edge-integrations/dist
-    - name: Compress built plugin
-      uses: montudor/action-zip@v1
-      with:
-        args: zip -qq -r main.zip pantheon-wordpress-edge-integrations
     - name: Release
       uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        files: |
-          main.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: Install composer dependencies and run tests
+    name: Lint and Test
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -23,3 +23,17 @@ The following testing tools are bundled, as well, for different forms of user in
 * [Robo](https://robo.li/) - For any testing that requires a live environment
 
 Combinations of these tools can be built into the `RoboFile.php`, e.g. spinning up a site and running TestCafe or PHPUnit tests that require database access against it.
+
+## Workflow
+
+`build` contains the current latest release and `main` contains the corresponding stable development version. Always work on the `main` branch and open up PRs against `main`.
+
+## Release Process
+
+1. Bump the version number in [pantheon-wordpress-edge-integrations.php](https://github.com/pantheon-systems/pantheon-wordpress-edge-integrations/blob/main/pantheon-wordpress-edge-integrations.php#L7)
+2. Create a pull request with production-ready code from `main` against `build`.
+3. After all tests pass, and automation makes the commit containing the build files, merge the PR into `build`.
+4. Locally checkout the `build` branch and pull the latest.
+5. Create a new tag: `git tag major.minor.patch`. Iterate on the previous [tag](https://github.com/pantheon-systems/pantheon-wordpress-edge-integrations/tags) as needed.
+6. Push the tag to the repo: `git push origin tag major.minor.patch`. This step triggers `release.yml` which will create a new release containing the compiled source files.
+7. Bump the version number in the `main` branch to major.minor.patch-dev via Pull Request once the release is published.

--- a/pantheon-wordpress-edge-integrations.php
+++ b/pantheon-wordpress-edge-integrations.php
@@ -4,7 +4,7 @@
  * Description: WordPress plugin to support Pantheon Edge Integrations and personalization features.
  * Author: Pantheon
  * Author URI: https://pantheon.io
- * Version: 0.2
+ * Version: 0.2.5
  *
  * @package Pantheon/EdgeIntegrations
  */


### PR DESCRIPTION
With these updates, `main` essentially becomes a stable development branch. Once a PR is made against `build` the new action, `build.yml`, will compile assets and make a commit to the PR.

The release workflow would be similar to the following:

1. Create a pull request with production-ready code from `main` against `build`.
2. After automation makes the commit containing the build files, merge the PR into `build`.
3. Locally checkout the `build` branch and pull the latest.
4. Create a new tag: `git tag major.minor.patch`
5. Push the tag to the repo: `git push origin tag major.minor.patch`. This step triggers `release.yml` which will create a new release containing the compiled source.
6. Update `main` version to `major.minor.patch-dev`.

Future development work should always be done off the `main` branch, and PRs should be opened against `main`.