### PR TITLE
Downgrade edge-integration-version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,8 @@
     "description": "WordPress plugin to support Pantheon Edge Integrations and personalization features",
     "type": "wordpress-plugin",
     "license": "MIT",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "repositories": [
         {
             "type": "composer",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "pantheon-systems/pantheon-edge-integrations": "dev-main"
+        "pantheon-systems/pantheon-edge-integrations": "*"
     },
     "require-dev": {
         "consolidation/robo": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a55dd6fc81a8b9d16e7e16925f27b50c",
+    "content-hash": "fa27cebe45bfce593a6b44c991bdb32c",
     "packages": [
         {
             "name": "pantheon-systems/pantheon-edge-integrations",
@@ -4595,12 +4595,11 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "stability-flags": {
-        "pantheon-systems/pantheon-edge-integrations": 20,
         "wordpress/wordpress": 20
     },
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],


### PR DESCRIPTION
In order to allow different versions of the edge integrations library (esp during development) we should allow any version of edge integrations to be required without locking to a specific version in our plugin