### PR TITLE
Fixes call_user_func_array warning

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -22,8 +22,6 @@ function bootstrap() {
 
 	// Load the Interest namespace.
 	Interest\bootstrap();
-
-	add_action( 'init', __NAMESPACE__ . '\\set_interest_header' );
 }
 
 /**


### PR DESCRIPTION
This will fix the warning on the [PR 23](https://pr-23-wp13n.pantheonsite.io/) site.

This hook is run in `Interest\bootstrap` [here](https://github.com/pantheon-systems/pantheon-wordpress-edge-integrations/blob/fix-set-interest-header/inc/interest.php#L21).