### PR TITLE
Fix "undefined array key" error

### DIFF
--- a/inc/geo.php
+++ b/inc/geo.php
@@ -49,10 +49,14 @@ function get_geo( string $data_type = '', $data = null, string $header = 'Audien
 	 * @param array The full, parsed Audience geo data as an array.
 	 */
 	$parsed_geo = apply_filters( 'pantheon.ei.parsed_geo_data', EI\HeaderData::parse( $header, $data ) );
-
 	// If no geo data type was passed, return all Audience data.
 	if ( empty( $data_type ) ) {
 		return json_encode( $parsed_geo );
+	}
+
+	// If no data exists for the data type, return an empty string.
+	if ( ! isset( $parsed_geo[ $data_type ] ) ) {
+		return '';
 	}
 
 	// If 'latlon' was requested, return the latitude and longitude.

--- a/tests/geoTest.php
+++ b/tests/geoTest.php
@@ -265,4 +265,21 @@ class geoTests extends TestCase {
 			'Filtered geo data does not match'
 		);
 	}
+
+	/**
+	 * Test that we dn't get an undefined array key error when calling a geo value that doesn't exist.
+	 */
+	public function testUndefinedArrayKey() {
+		// Reset the geo data to nothing.
+		add_filter( 'pantheon.ei.parsed_geo_data', function() {
+			return [];
+		}, 10 );
+
+		$this->assertEmpty( Geo\get_geo( 'country' ) );
+
+		// Reset the geo back to something resembling real data.
+		add_filter( 'pantheon.ei.parsed_geo_data', function() {
+			return EI\HeaderData::parse( 'Audience-Set', $this->mockAudienceData()[0]['US'] );
+		}, 10 );
+	}
 }


### PR DESCRIPTION
When calling `get_geo` and passing a value that does not exist, we get an "undefined array key" PHP fatal error.

This PR adds graceful handling in the eventuality that we're requesting data that is _allowed_ but was not returned from the CDN.