### PR TITLE
Don't remove the config before build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,9 @@ jobs:
       run: |
         git config --local user.email "bot@getpantheon.com"
         git config --local user.name "Pantheon Automation"
-        rm -rf assets/
-        git add -f dist/ vendor/ assets/
         npm run dev
-        git rm -rf config/
+        rm -rf assets/ config/
+        git add -f dist/ vendor/ assets/ config/
         git add -f dist/js/assets.js
         git status
         git commit -m "Built assets"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,10 @@ jobs:
       run: |
         git config --local user.email "bot@getpantheon.com"
         git config --local user.name "Pantheon Automation"
-        rm -rf assets/ config/
-        git add -f dist/ vendor/ assets/ config/
+        rm -rf assets/
+        git add -f dist/ vendor/ assets/
         npm run dev
+        git rm -rf config/
         git add -f dist/js/assets.js
         git status
         git commit -m "Built assets"


### PR DESCRIPTION
Builds are failing because `config/webpack.config.js` doesn't exist after it's been `rm -rf`'d. 

This PR moves the ~`rm -rf config/` to after the build is complete~ `npm run dev` up to avoid the error.