### PR TITLE
[EI-85] Set Vary headers

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -24,7 +24,7 @@ function bootstrap() {
 	Interest\bootstrap();
 
 	// Set the Vary headers.
-	add_action( 'init' , __NAMESPACE__ . '\\set_vary_headers' );
+	add_action( 'init', __NAMESPACE__ . '\\set_vary_headers' );
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -64,5 +64,6 @@ function get_supported_vary_headers() : array {
 function set_vary_headers() {
 	$supported_vary_headers = get_supported_vary_headers();
 
-	header( 'Vary: ' . implode( ', ', array_keys( $supported_vary_headers ) ), false );
+	// Set the Vary headers.
+	header( 'Vary: ' . implode( ', ', $supported_vary_headers ), false );
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -30,7 +30,7 @@ function bootstrap() {
 /**
  * Get an array of vary headers supported by the plugin.
  *
- * @return array
+ * @return array Array of supported vary header keys.
  */
 function get_supported_vary_headers() : array {
 	/**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -22,6 +22,9 @@ function bootstrap() {
 
 	// Load the Interest namespace.
 	Interest\bootstrap();
+
+	// Set the Vary headers.
+	add_action( 'init' , __NAMESPACE__ . '\\set_vary_headers' );
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -54,11 +54,5 @@ function get_supported_vary_headers() : array {
 function set_vary_headers() {
 	$supported_vary_headers = get_supported_vary_headers();
 
-	foreach ( $supported_vary_headers as $header => $enabled ) {
-		if ( ! $enabled ) {
-			continue;
-		}
-
-		header( "Vary: $header", false );
-	}
+	header( 'Vary: ' . implode( ', ', array_keys( $supported_vary_headers ) ), false );
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -39,6 +39,12 @@ function get_supported_vary_headers() : array {
 		'Interest' => true,
 	];
 
+	// Omit headers that are not supported.
+	$key = array_search( false, $defaults );
+	if ( false !== $defaults ) {
+		unset( $defaults[ $key ] );
+	}
+
 	/**
 	 * Allow developers to modify the vary headers supported by the plugin.
 	 *

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -52,14 +52,8 @@ function get_supported_vary_headers() : array {
 		unset( $defaults[ $key ] );
 	}
 
-	/**
-	 * Allow developers to modify the vary headers supported by the plugin.
-	 *
-	 * Array keys are vary headers, and values are whether or not they are supported.
-	 *
-	 * @param array $defaults Array of vary headers supported by the plugin.
-	 */
-	return apply_filters( 'pantheon.ei.supported_vary_headers', $defaults );
+	// Return the modified array of supported vary header keys.
+	return array_keys( $defaults );
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -47,7 +47,7 @@ function get_supported_vary_headers() : array {
 	] );
 
 	// Omit headers that are not supported.
-	$key = array_search( false, $defaults );
+	$key = array_search( false, $defaults, true );
 	if ( false !== $defaults ) {
 		unset( $defaults[ $key ] );
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -33,11 +33,18 @@ function bootstrap() {
  * @return array
  */
 function get_supported_vary_headers() : array {
-	$defaults = [
+	/**
+	 * Allow developers to modify the vary headers supported by the plugin.
+	 *
+	 * Array keys are vary headers, and values are whether or not they are supported.
+	 *
+	 * @param array $defaults Array of vary headers supported by the plugin.
+	 */
+	$defaults = apply_filters( 'pantheon.ei.supported_vary_headers', [
 		'Audience-Set' => true,
 		'Audience' => false,
 		'Interest' => true,
-	];
+	] );
 
 	// Omit headers that are not supported.
 	$key = array_search( false, $defaults );

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -35,11 +35,7 @@ class testsBase extends TestCase {
 	 * Test the supported vary headers.
 	 */
 	public function testSupportedVaryHeaders() {
-		$this->assertEquals( [
-			'Audience-Set' => true,
-			'Audience'     => false,
-			'Interest'     => true,
-		],
+		$this->assertEquals( [ 'Audience-Set', 'Interest' ],
 		get_supported_vary_headers(),
 		'The vary headers supported do not match.'
 		);


### PR DESCRIPTION
In the WordPress plugin, we aren't actually setting the vary headers. 

The `set_vary_headers` function here: 
https://github.com/pantheon-systems/pantheon-wordpress-edge-integrations/blob/29f686ae6828eac1166a40af75f31987bf6d4276/inc/namespace.php#L55-L62

...is supposed to set the headers, but that function is never actually called.

This PR
* simplifies the `header` function call by sending it a concatenated list of headers rather than looping through the available options
* unsets the unsupported vary header keys
* fires set_vary_headers on init