### PR TITLE
[EI-84] fix failing builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         git config --local user.name "Pantheon Automation"
         rm -rf assets/ config/
         git add -f dist/ vendor/ assets/ config/
-        git add -f dist/js/assets.js dist/js/assets.min.js
+        git add -f dist/js/assets.min.js
         git status
         git commit -m "Built assets"
     - name: Push changes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,10 @@ jobs:
       run: |
         git config --local user.email "bot@getpantheon.com"
         git config --local user.name "Pantheon Automation"
-        rm -rf assets/ config/
-        git add -f dist/ vendor/ assets/ config/
+        git add -f dist/ vendor/
         npm run dev
-        git add -f dist/js/assets.js
+        rm -rf assets/ config/
+        git add -f dist/js/assets.js assets/ config/
         git status
         git commit -m "Built assets"
     - name: Push changes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         npm run dev
         rm -rf assets/ config/
         git add -f dist/ vendor/ assets/ config/
-        git add -f dist/js/assets.js
+        git add -f dist/js/assets.js dist/js/assets.min.js
         git status
         git commit -m "Built assets"
     - name: Push changes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,6 @@ jobs:
       run: |
         git config --local user.email "bot@getpantheon.com"
         git config --local user.name "Pantheon Automation"
-        npm run dev
         rm -rf assets/ config/
         git add -f dist/ vendor/ assets/ config/
         git add -f dist/js/assets.js dist/js/assets.min.js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,8 @@ jobs:
         git config --local user.name "Pantheon Automation"
         rm -rf assets/ config/
         git add -f dist/ vendor/ assets/ config/
-        git add -f dist/js/assets.min.js
+        npm run dev
+        git add -f dist/js/assets.js
         git status
         git commit -m "Built assets"
     - name: Push changes

--- a/assets/js/interest-count.js
+++ b/assets/js/interest-count.js
@@ -130,7 +130,7 @@ function getInterests() {
 			let interestTags = Object.keys( interestTagsCount );
 
 			if ( interestTags.length > 0 ) {
-				const CookieAttributes = { expires: parseInt( localizedObj.cookie_expiration ) };
+				const CookieAttributes = { expires: parseInt( cookieExpiration ) };
 				// Set interest cookie with popular tags, separated by |, and any attributes.
 				cookies.set( 'interest', interestTags.join( '|' ), CookieAttributes );
 			}


### PR DESCRIPTION
This PR attempts to fix the failing release builds:

* fixes the `no-unused-vars` webpack build error coming from `cookieExpiration` being defined but unused
* adds the minified javascript file to the committed build file and removes the unminified file
* removes the `npm run dev` which removes the minified file if it's run after `npm run build`

Build test: https://github.com/pantheon-systems/pantheon-wordpress-edge-integrations/pull/70/commits/c9888e6f0319fcf0ebfae55663ed563f5c03f2fd