### PR TITLE
[EI-101] integrate GA & GTM

### DIFF
--- a/assets/js/assets.js
+++ b/assets/js/assets.js
@@ -1,1 +1,2 @@
 import './interest-count';
+import './gtm-headers';

--- a/assets/js/gtm-headers.js
+++ b/assets/js/gtm-headers.js
@@ -1,0 +1,26 @@
+/* global eiGtm */
+// eslint-disable-next-line no-var
+var Pantheon = window.Pantheon || {};
+
+Pantheon.varyHeaders = eiGtm.headersEnabled;
+
+Pantheon.GTM = {
+	interest: Pantheon.varyHeaders.includes( 'Interest' ) ? eiGtm.interest : null,
+	geo: Pantheon.varyHeaders.includes( 'Audience' ) || Pantheon.varyHeaders.includes( 'Audience-Set' ) ? eiGtm.geo : null,
+};
+
+/**
+ * Push personalization data to GTM.
+ */
+Pantheon.GTM.dataPush = function () {
+	window.dataLayer = window.dataLayer || [];
+	window.dataLayer.push( {
+		'event': 'pzn',
+		'audience': {
+			'geo': Pantheon.GTM.geo,
+		},
+		'interest': Pantheon.GTM.interest,
+	} );
+};
+
+Pantheon.GTM.dataPush();

--- a/assets/js/interest-count.js
+++ b/assets/js/interest-count.js
@@ -1,4 +1,4 @@
-/*global pantheon_ei*/
+/*global eiInterest*/
 /**
  * @file
  * Count interests and set cookie for interest header.
@@ -76,7 +76,7 @@ function getInterests() {
 		 */
 		constructor() {
 			// localStorage key.
-			this.key = 'pantheon_ei.interest';
+			this.key = 'eiInterest.interest';
 		}
 
 		/**
@@ -103,7 +103,7 @@ function getInterests() {
 	if ( ! runOnce ) {
 		runOnce = true;
 
-		const localizedObj = pantheon_ei;
+		const localizedObj = eiInterest;
 
 		// How many times should a tag be visited before adding to interest header.
 		const popularityCount = localizedObj.interest_threshold ? localizedObj.interest_threshold : 3;

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     },
     "autoload": {
         "files": [
+            "inc/audience.php",
             "inc/geo.php",
             "inc/interest.php",
             "inc/namespace.php"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "autoload": {
         "files": [
-            "inc/audience.php",
+            "inc/analytics.php",
             "inc/geo.php",
             "inc/interest.php",
             "inc/namespace.php"

--- a/composer.lock
+++ b/composer.lock
@@ -99,16 +99,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.2.9",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "a951f614bd64dcd26137bc9b7b2637ddcfc57649"
+                "reference": "5d8e574bb0e69188786b8ef77d43341222a41a71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/a951f614bd64dcd26137bc9b7b2637ddcfc57649",
-                "reference": "a951f614bd64dcd26137bc9b7b2637ddcfc57649",
+                "url": "https://api.github.com/repos/composer/semver/zipball/5d8e574bb0e69188786b8ef77d43341222a41a71",
+                "reference": "5d8e574bb0e69188786b8ef77d43341222a41a71",
                 "shasum": ""
             },
             "require": {
@@ -160,7 +160,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.2.9"
+                "source": "https://github.com/composer/semver/tree/3.3.1"
             },
             "funding": [
                 {
@@ -176,7 +176,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-04T13:58:43+00:00"
+            "time": "2022-03-16T11:22:07+00:00"
         },
         {
             "name": "consolidation/annotated-command",
@@ -711,29 +711,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^8.0",
+                "doctrine/coding-standard": "^9",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-phpunit": "^0.12",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.22"
             },
             "type": "library",
             "autoload": {
@@ -760,7 +761,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
             },
             "funding": [
                 {
@@ -776,7 +777,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-10T18:47:58+00:00"
+            "time": "2022-03-03T08:28:38+00:00"
         },
         {
             "name": "fig-r/psr2r-sniffer",
@@ -1002,25 +1003,29 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.2",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+            },
             "require-dev": {
-                "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^7.1"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
             "autoload": {
@@ -1045,7 +1050,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
             },
             "funding": [
                 {
@@ -1053,7 +1058,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T09:40:50+00:00"
+            "time": "2022-03-03T13:19:32+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -1623,16 +1628,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.14",
+            "version": "9.2.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "9f4d60b6afe5546421462b76cd4e633ebc364ab4"
+                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/9f4d60b6afe5546421462b76cd4e633ebc364ab4",
-                "reference": "9f4d60b6afe5546421462b76cd4e633ebc364ab4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
+                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
                 "shasum": ""
             },
             "require": {
@@ -1688,7 +1693,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.14"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.15"
             },
             "funding": [
                 {
@@ -1696,7 +1701,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-28T12:38:02+00:00"
+            "time": "2022-03-07T09:28:20+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1941,16 +1946,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.16",
+            "version": "9.5.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "5ff8c545a50226c569310a35f4fa89d79f1ddfdc"
+                "reference": "35ea4b7f3acabb26f4bb640f8c30866c401da807"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5ff8c545a50226c569310a35f4fa89d79f1ddfdc",
-                "reference": "5ff8c545a50226c569310a35f4fa89d79f1ddfdc",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/35ea4b7f3acabb26f4bb640f8c30866c401da807",
+                "reference": "35ea4b7f3acabb26f4bb640f8c30866c401da807",
                 "shasum": ""
             },
             "require": {
@@ -1980,7 +1985,7 @@
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3.4",
+                "sebastian/type": "^3.0",
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
@@ -2028,7 +2033,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.16"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.19"
             },
             "funding": [
                 {
@@ -2040,7 +2045,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-23T17:10:58+00:00"
+            "time": "2022-03-15T09:57:31+00:00"
         },
         {
             "name": "psr/container",
@@ -3052,28 +3057,28 @@
         },
         {
             "name": "sebastian/type",
-            "version": "2.3.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
+                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
-                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
+                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3096,7 +3101,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.0.0"
             },
             "funding": [
                 {
@@ -3104,7 +3109,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-15T12:49:02+00:00"
+            "time": "2022-03-15T09:54:48+00:00"
         },
         {
             "name": "sebastian/version",
@@ -3474,16 +3479,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.0.5",
+            "version": "v6.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "6646c13f787057d64701a3a0235cf9567c6ccbbd"
+                "reference": "52b888523545b0b4049ab9ce48766802484d7046"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/6646c13f787057d64701a3a0235cf9567c6ccbbd",
-                "reference": "6646c13f787057d64701a3a0235cf9567c6ccbbd",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/52b888523545b0b4049ab9ce48766802484d7046",
+                "reference": "52b888523545b0b4049ab9ce48766802484d7046",
                 "shasum": ""
             },
             "require": {
@@ -3517,7 +3522,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.0.5"
+                "source": "https://github.com/symfony/filesystem/tree/v6.0.6"
             },
             "funding": [
                 {
@@ -3533,7 +3538,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-28T07:42:30+00:00"
+            "time": "2022-03-02T12:58:14+00:00"
         },
         {
             "name": "symfony/finder",
@@ -3598,7 +3603,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -3660,7 +3665,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -3680,7 +3685,7 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
@@ -3741,7 +3746,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -3761,7 +3766,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -3825,7 +3830,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -3845,7 +3850,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
@@ -3908,7 +3913,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.25.0"
             },
             "funding": [
                 {

--- a/inc/analytics.php
+++ b/inc/analytics.php
@@ -187,7 +187,7 @@ function sanitize_gtm_code( string $gtm_code ) : string {
  * 2. false - if a developer has not defined a GTM code via the filter (the default state). In this case, the option in the admin is displayed.
  * 3. A string - if a developer has defined a GTM code via the filter. In this case, the option in the admin is hidden.
  *
- * @param bool|string $gtm_code
+ * @param bool|string $gtm_code The GTM code.
  *
  * @return bool|string
  */

--- a/inc/analytics.php
+++ b/inc/analytics.php
@@ -64,7 +64,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 function enqueue_scripts() {
 	$gtm_code = get_gtm_code();
 
-	// Bail early if we don't have a GTM code.
+	// Bail early only if we don't have a GTM code. If the code is provided externally, we still want to run the script.
 	if ( ! $gtm_code ) {
 		return;
 	}

--- a/inc/analytics.php
+++ b/inc/analytics.php
@@ -60,13 +60,12 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 }
 
 /**
- * Enqueue the GTM script.
+ * Localize the GTM script.
  */
-function enqueue_scripts() {
+function localize_script() {
 	$vary_headers = WP\get_supported_vary_headers();
-	wp_enqueue_script( 'ei-gtm', plugin_dir_url( dirname( __FILE__ ) ) . '/assets/js/gtm_headers.js', [], '1.0.0', true );
 
-	wp_localize_script( 'ei-gtm', 'eiGtm', [
+	wp_localize_script( 'pantheon-ei', 'eiGtm', [
 		'headersEnabled' => $vary_headers,
 		'geo' => WP\Geo\get_geo(),
 		'interest' => WP\Interest\get_interest(),

--- a/inc/analytics.php
+++ b/inc/analytics.php
@@ -63,18 +63,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
  * Enqueue the GTM script.
  */
 function enqueue_scripts() {
-	$gtm_code = get_gtm_code();
-
-	// Bail early only if we don't have a GTM code. If the code is provided externally, we still want to run the script.
-	if ( ! $gtm_code ) {
-		return;
-	}
-
 	$vary_headers = WP\get_supported_vary_headers();
 	wp_enqueue_script( 'ei-gtm', plugin_dir_url( dirname( __FILE__ ) ) . '/assets/js/gtm_headers.js', [], '1.0.0', true );
 
 	wp_localize_script( 'ei-gtm', 'eiGtm', [
-		'gtmCode' => $gtm_code,
 		'headersEnabled' => $vary_headers,
 		'geo' => WP\Geo\get_geo(),
 		'interest' => WP\Interest\get_interest(),

--- a/inc/analytics.php
+++ b/inc/analytics.php
@@ -25,8 +25,8 @@ function bootstrap() {
 function after_head() {
 	$gtm_code = get_gtm_code();
 
-	// Bail early if we don't have a GTM code.
-	if ( ! $gtm_code ) {
+	// Bail early if we don't have a GTM code or if the GTM code is being overridden externally.
+	if ( is_bool( $gtm_code ) ) {
 		return;
 	}
 	?>
@@ -46,8 +46,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 function after_body() {
 	$gtm_code = get_gtm_code();
 
-	// Bail early if we don't have a GTM code.
-	if ( ! $gtm_code ) {
+	// Bail early if we don't have a GTM code or if the GTM code is being overridden externally.
+	if ( is_bool( $gtm_code ) ) {
 		return;
 	}
 	?>

--- a/inc/analytics.php
+++ b/inc/analytics.php
@@ -17,6 +17,7 @@ function bootstrap() {
 	add_action( 'wp_body_open', __NAMESPACE__ . '\\after_body', 1 );
 	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
 	add_action( 'admin_init', __NAMESPACE__ . '\\register_setting' );
+	add_filter( 'pantheon.ei.gtm_code', __NAMESPACE__ . '\\filter_gtm_code', 1 );
 }
 
 /**
@@ -182,3 +183,27 @@ function sanitize_gtm_code( string $gtm_code ) : string {
 	return sanitize_text_field( $gtm_code );
 }
 
+/**
+ * Maybe filter the GTM code.
+ *
+ * The GTM code may come in three different options:
+ * 1. true - if a developer wants to use their own analytics plugin to manage GTM. In this case, true overrides the filter and disables the option in the admin.
+ * 2. false - if a developer has not defined a GTM code via the filter (the default state). In this case, the option in the admin is displayed.
+ * 3. A string - if a developer has defined a GTM code via the filter. In this case, the option in the admin is hidden.
+ *
+ * @param bool|string $gtm_code
+ *
+ * @return bool|string
+ */
+function filter_gtm_code( $gtm_code ) {
+	// Check for stored value for GTM code from the option in the admin..
+	$option = get_option( 'pantheon_ei_gtm_code', $gtm_code );
+
+	// If the option is true or false, we're either overriding the admin option or an option has not been set. In that case, we don't need to filter anything.
+	if ( is_bool( $option ) ) {
+		return $gtm_code;
+	}
+
+	// If the option is a string, it is the stored admin GTM code value, so we should filter the GTM code with the one stored in the database.
+	return $option;
+}

--- a/inc/analytics.php
+++ b/inc/analytics.php
@@ -88,7 +88,7 @@ function enqueue_scripts() {
  * @return bool|string The GTM code, or false if none exists.
  */
 function get_gtm_code() {
-	$gtm_code = apply_filters( 'pantheon.ei.gtm_code', '__return_false' );
+	$gtm_code = apply_filters( 'pantheon.ei.gtm_code', false );
 
 	// Bail if we don't have a valid GTM code.
 	if ( ! is_string( $gtm_code ) || false === stripos( $gtm_code, 'GTM' ) ) {

--- a/inc/analytics.php
+++ b/inc/analytics.php
@@ -83,8 +83,9 @@ function enqueue_scripts() {
 /**
  * Get the GTM code.
  * If no GTM code exists, return false.
+ * Alternately, the user can filter this value as "true" if they want to use their own Google Analytics/Google Tag Manager plugin to store/manage their GTM code.
  *
- * @return string|false The GTM code, or false if none exists.
+ * @return bool|string The GTM code, or false if none exists.
  */
 function get_gtm_code() {
 	$gtm_code = apply_filters( 'pantheon.ei.gtm_code', '__return_false' );

--- a/inc/analytics.php
+++ b/inc/analytics.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Adds integration with Google Analytics and Google Tag Manager.
+ *
+ * @package Pantheon/EdgeIntegrations
+ */
+
+namespace Pantheon\EI\WP\Analytics;
+
+use Pantheon\EI\WP;
+
+/**
+ * Kick off the plugin.
+ */
+function bootstrap() {
+	add_action( 'wp_head', __NAMESPACE__ . '\\after_head', 1 );
+	add_action( 'wp_body_open', __NAMESPACE__ . '\\after_body', 1 );
+	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
+
+}
+
+/**
+ * Add the GTM code to the <head> element.
+ */
+function after_head() {
+	$gtm_code = get_gtm_code();
+
+	// Bail early if we don't have a GTM code.
+	if ( ! $gtm_code ) {
+		return;
+	}
+	?>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','<?php echo esc_attr( $gtm_code ); ?>');</script>
+<!-- End Google Tag Manager -->
+	<?php
+}
+
+/**
+ * Add the GTM code to the <body> element.
+ */
+function after_body() {
+	$gtm_code = get_gtm_code();
+
+	// Bail early if we don't have a GTM code.
+	if ( ! $gtm_code ) {
+		return;
+	}
+	?>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<?php echo esc_attr( $gtm_code ); ?>"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+	<?php
+}
+
+/**
+ * Enqueue the GTM script.
+ */
+function enqueue_scripts() {
+	$gtm_code = get_gtm_code();
+
+	// Bail early if we don't have a GTM code.
+	if ( ! $gtm_code ) {
+		return;
+	}
+
+	$vary_headers = WP\get_supported_vary_headers();
+	wp_enqueue_script( 'ei-gtm', plugin_dir_url( dirname( __FILE__ ) ) . '/assets/js/gtm_headers.js', [], '1.0.0', true );
+
+	wp_localize_script( 'ei-gtm', 'eiGtm', [
+		'gtmCode' => $gtm_code,
+		'headersEnabled' => $vary_headers,
+		'geo' => WP\Geo\get_geo(),
+		'interest' => WP\Interest\get_interest(),
+	] );
+}
+
+/**
+ * Get the GTM code.
+ * If no GTM code exists, return false.
+ *
+ * @return string|false The GTM code, or false if none exists.
+ */
+function get_gtm_code() {
+	$gtm_code = apply_filters( 'pantheon.ei.gtm_code', '__return_false' );
+
+	// Bail if we don't have a valid GTM code.
+	if ( ! is_string( $gtm_code ) || false === stripos( $gtm_code, 'GTM' ) ) {
+		return false;
+	}
+
+	return $gtm_code;
+}

--- a/inc/analytics.php
+++ b/inc/analytics.php
@@ -21,7 +21,7 @@ function bootstrap() {
 	add_action( 'wp_head', $n( 'after_head' ), 1 );
 	add_action( 'wp_body_open', $n( 'after_body' ), 1 );
 	add_action( 'pantheon.ei.after_enqueue_script', $n( 'localize_script' ) );
-	add_action( 'admin_init', $n( 'register_setting' ) );
+	add_action( 'admin_init', $n( 'register_ei_settings' ) );
 	add_filter( 'pantheon.ei.gtm_code', $n( 'filter_gtm_code' ), 1 );
 }
 
@@ -98,7 +98,7 @@ function get_gtm_code() {
 /**
  * Register the GTM setting and add the setting field.
  */
-function register_setting() {
+function register_ei_settings() {
 	$gtm_code = get_gtm_code();
 
 	// Bail early and don't register the setting if we're overriding GTM in the EI plugin.
@@ -115,7 +115,7 @@ function register_setting() {
 	}
 
 	// Register the setting.
-	\register_setting( 'general', 'pantheon_ei_gtm_code', [
+	register_setting( 'general', 'pantheon_ei_gtm_code', [
 		'sanitize_callback' => __NAMESPACE__ . '\\sanitize_gtm_code',
 	] );
 

--- a/inc/analytics.php
+++ b/inc/analytics.php
@@ -10,7 +10,7 @@ namespace Pantheon\EI\WP\Analytics;
 use Pantheon\EI\WP;
 
 /**
- * Kick off the plugin.
+ * Kick off analytics.
  */
 function bootstrap() {
 	// Helper variable function that simplifies callbacks.

--- a/inc/analytics.php
+++ b/inc/analytics.php
@@ -13,11 +13,16 @@ use Pantheon\EI\WP;
  * Kick off the plugin.
  */
 function bootstrap() {
-	add_action( 'wp_head', __NAMESPACE__ . '\\after_head', 1 );
-	add_action( 'wp_body_open', __NAMESPACE__ . '\\after_body', 1 );
-	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
-	add_action( 'admin_init', __NAMESPACE__ . '\\register_setting' );
-	add_filter( 'pantheon.ei.gtm_code', __NAMESPACE__ . '\\filter_gtm_code', 1 );
+	// Helper variable function that simplifies callbacks.
+	$n = function( $callback ) {
+		return __NAMESPACE__ . "\\$callback";
+	};
+
+	add_action( 'wp_head', $n( 'after_head' ), 1 );
+	add_action( 'wp_body_open', $n( 'after_body' ), 1 );
+	add_action( 'wp_enqueue_scripts', $n( 'localize_script' ) );
+	add_action( 'admin_init', $n( 'register_setting' ) );
+	add_filter( 'pantheon.ei.gtm_code', $n( 'filter_gtm_code' ), 1 );
 }
 
 /**

--- a/inc/analytics.php
+++ b/inc/analytics.php
@@ -16,7 +16,7 @@ function bootstrap() {
 	add_action( 'wp_head', __NAMESPACE__ . '\\after_head', 1 );
 	add_action( 'wp_body_open', __NAMESPACE__ . '\\after_body', 1 );
 	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
-
+	add_action( 'admin_init', __NAMESPACE__ . '\\register_setting' );
 }
 
 /**
@@ -97,3 +97,88 @@ function get_gtm_code() {
 
 	return $gtm_code;
 }
+
+/**
+ * Register the GTM setting and add the setting field.
+ */
+function register_setting() {
+	$gtm_code = get_gtm_code();
+
+	// Bail early and don't register the setting if we're overriding GTM in the EI plugin.
+	if ( true === $gtm_code ) {
+		return;
+	}
+
+	// Get the option value so we can check if GTM is set in the plugin or via a filter.
+	$option = get_option( 'pantheon_ei_gtm_code' );
+
+	// If the $gtm_code is a string, but we don't have an option, it was added via filter, so bail here and don't display the option in the admin.
+	if ( is_string( $gtm_code ) && ! $option ) {
+		return;
+	}
+
+	// Regiter the setting.
+	\register_setting( 'general', 'pantheon_ei_gtm_code', [
+		'sanitize_callback' => __NAMESPACE__ . '\\sanitize_gtm_code',
+	] );
+
+	// Add the setting to the admin.
+	add_settings_field(
+		'gtm-code',
+		__( 'Google Tag Manager Code', 'pantheon-wordpress-edge-integrations' ),
+		__NAMESPACE__ . '\\render_gtm_code_field',
+		'general',
+		'default',
+		[
+			'id' => 'gtm-code',
+			'label_for' => 'gtm-code',
+			'option_name' => 'pantheon_ei_gtm_code',
+		]
+	);
+}
+
+/**
+ * Displays the input field for the Google Tag Manager code option field.
+ *
+ * @param array $args The arguments for the field passed from add_settings_field.
+ */
+function render_gtm_code_field( array $args ) {
+	$id = $args['id'];
+	$option_name = $args['option_name'];
+	$value = get_option( $option_name, '' );
+	?>
+	<input
+		type="text"
+		id="<?php echo esc_attr( $id ); ?>"
+		name="<?php echo esc_attr( $option_name ); ?>"
+		value="<?php echo esc_attr( $value ); ?>"
+		class="regular-text"
+		placeholder="GTM-XXXXXX"
+	/>
+	<p class="description">
+		<?php esc_html_e( 'Your Google Tag Manager (GTM) code. This is required for Google Tag Manager integration to work.', 'pantheon-wordpress-edge-integrations' ); ?>
+	</p>
+	<?php
+}
+
+/**
+ * Sanitize the GTM code.
+ *
+ * @param string $gtm_code The (dirty) GTM code.
+ *
+ * @return string The sanitized GTM code.
+ */
+function sanitize_gtm_code( string $gtm_code ) : string {
+	// Bail early if we don't have a GTM code.
+	if ( ! $gtm_code ) {
+		return '';
+	}
+
+	// GTM codes should contain GTM in them. Other analytics codes are not supported.
+	if ( false === stripos( $gtm_code, 'GTM' ) ) {
+		return '';
+	}
+
+	return sanitize_text_field( $gtm_code );
+}
+

--- a/inc/analytics.php
+++ b/inc/analytics.php
@@ -20,7 +20,7 @@ function bootstrap() {
 
 	add_action( 'wp_head', $n( 'after_head' ), 1 );
 	add_action( 'wp_body_open', $n( 'after_body' ), 1 );
-	add_action( 'wp_enqueue_scripts', $n( 'localize_script' ) );
+	add_action( 'pantheon.ei.after_enqueue_script', $n( 'localize_script' ) );
 	add_action( 'admin_init', $n( 'register_setting' ) );
 	add_filter( 'pantheon.ei.gtm_code', $n( 'filter_gtm_code' ), 1 );
 }

--- a/inc/analytics.php
+++ b/inc/analytics.php
@@ -114,7 +114,7 @@ function register_setting() {
 		return;
 	}
 
-	// Regiter the setting.
+	// Register the setting.
 	\register_setting( 'general', 'pantheon_ei_gtm_code', [
 		'sanitize_callback' => __NAMESPACE__ . '\\sanitize_gtm_code',
 	] );

--- a/inc/analytics.php
+++ b/inc/analytics.php
@@ -90,8 +90,8 @@ function enqueue_scripts() {
 function get_gtm_code() {
 	$gtm_code = apply_filters( 'pantheon.ei.gtm_code', false );
 
-	// Bail if we don't have a valid GTM code.
-	if ( ! is_string( $gtm_code ) || false === stripos( $gtm_code, 'GTM' ) ) {
+	// Return false if we don't have a valid GTM code.
+	if ( ! $gtm_code || is_string( $gtm_code ) && false === stripos( $gtm_code, 'GTM' ) ) {
 		return false;
 	}
 

--- a/inc/interest.php
+++ b/inc/interest.php
@@ -19,31 +19,19 @@ function bootstrap() {
 	};
 
 	add_action( 'init', $n( 'set_interest_header' ) );
-	add_action( 'wp_enqueue_scripts', $n( 'register_script' ) );
+	add_action( 'wp_enqueue_scripts', $n( 'localize_script' ) );
 }
 
 /**
- * Registers the script.
+ * Pass interest data to the script.
  *
  * @return void
  */
-function register_script() {
-	if ( ! is_singular( get_interest_allowed_post_types() ) ) {
-		return;
-	}
-
+function localize_script() {
 	global $post;
 	$post_id = $post->ID;
-
-	/* Use minified libraries if SCRIPT_DEBUG is turned off. */
-	$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
-	wp_enqueue_script( 'pantheon-ei-interest', plugins_url( '/dist/js/assets' . $suffix . '.js', PANTHEON_EDGE_INTEGRATIONS_FILE ), [], PANTHEON_EDGE_INTEGRATIONS_VERSION, true );
-
 	$taxonomy = get_interest_taxonomy();
-	$post_terms = wp_get_post_terms( $post_id, $taxonomy, [ 'fields' => 'slugs' ] );
-	if ( ! $post_terms ) {
-		return;
-	}
+	$post_terms = wp_get_post_terms( $post_id, $taxonomy, [ 'fields' => 'slugs' ] ) ?: [];
 
 	wp_localize_script(
 		'pantheon-ei-interest',

--- a/inc/interest.php
+++ b/inc/interest.php
@@ -19,7 +19,7 @@ function bootstrap() {
 	};
 
 	add_action( 'init', $n( 'set_interest_header' ) );
-	add_action( 'wp_enqueue_scripts', $n( 'localize_script' ) );
+	add_action( 'pantheon.ei.after_enqueue_script', $n( 'localize_script' ) );
 }
 
 /**

--- a/inc/interest.php
+++ b/inc/interest.php
@@ -34,8 +34,8 @@ function localize_script() {
 	$post_terms = wp_get_post_terms( $post_id, $taxonomy, [ 'fields' => 'slugs' ] ) ?: [];
 
 	wp_localize_script(
-		'pantheon-ei-interest',
-		'pantheon_ei',
+		'pantheon-ei',
+		'eiInterest',
 		[
 			/**
 			 * Allow engineers to modify terms before they are localized.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -13,6 +13,11 @@ namespace Pantheon\EI\WP;
  * Kick it off!
  */
 function bootstrap() {
+	// Helper variable function that simplifies callbacks.
+	$n = function( $callback ) {
+		return __NAMESPACE__ . "\\$callback";
+	};
+
 	define( 'PANTHEON_EDGE_INTEGRATIONS_DIR', dirname( __DIR__, 1 ) );
 	define( 'PANTHEON_EDGE_INTEGRATIONS_FILE', PANTHEON_EDGE_INTEGRATIONS_DIR . '/' . basename( dirname( __DIR__, 1 ) ) . '.php' );
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -37,7 +37,7 @@ function bootstrap() {
 }
 
 /**
- * Registers & enequeues the script.
+ * Registers & enqueues the script.
  *
  * @return void
  */

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -24,7 +24,25 @@ function bootstrap() {
 	Interest\bootstrap();
 
 	// Set the Vary headers.
-	add_action( 'init', __NAMESPACE__ . '\\set_vary_headers' );
+	add_action( 'init', $n( 'set_vary_headers' ) );
+
+	// Enqueue the script.
+	add_action( 'wp_enqueue_scripts', $n( 'register_script' ) );
+}
+
+/**
+ * Registers & enequeues the script.
+ *
+ * @return void
+ */
+function register_script() {
+	/* Use minified libraries if SCRIPT_DEBUG is turned off. */
+	$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+
+	// Enqueue the script anytime we're not in the admin.
+	if ( ! is_admin() ) {
+		wp_enqueue_script( 'pantheon-ei', plugins_url( '/dist/js/assets' . $suffix . '.js', PANTHEON_EDGE_INTEGRATIONS_FILE ), [], PANTHEON_EDGE_INTEGRATIONS_VERSION, true );
+	}
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -48,6 +48,18 @@ function enqueue_script() {
 	// Enqueue the script anytime we're not in the admin.
 	if ( ! is_admin() ) {
 		wp_enqueue_script( 'pantheon-ei', plugins_url( '/dist/js/assets' . $suffix . '.js', PANTHEON_EDGE_INTEGRATIONS_FILE ), [], PANTHEON_EDGE_INTEGRATIONS_VERSION, true );
+
+		/**
+		 * Allow developers to hook in after the pantheon-ei script is enqueued.
+		 * @todo Write documentation for this hook.
+		 * @hook pantheon.ei.enqueue_script
+		 * @param string $plugin_version The plugin version.
+		 * @param string $plugin_file The plugin file path.
+		 */
+		do_action( 'pantheon.ei.after_enqueue_script', [
+			'plugin_version' => PANTHEON_EDGE_INTEGRATIONS_VERSION,
+			'plugin_file'    => PANTHEON_EDGE_INTEGRATIONS_FILE,
+		] );
 	}
 }
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -46,7 +46,8 @@ function enqueue_script() {
 
 	// Enqueue the script anytime we're not in the admin.
 	if ( ! is_admin() ) {
-		wp_enqueue_script( 'pantheon-ei', plugins_url( '/dist/js/assets' . $suffix . '.js', PANTHEON_EDGE_INTEGRATIONS_FILE ), [], PANTHEON_EDGE_INTEGRATIONS_VERSION, true );
+		$path = ! empty( $suffix ) ? "/dist/js/assets$suffix.js" : '/assets/js/assets.js';
+		wp_enqueue_script( 'pantheon-ei', plugins_url( $path, PANTHEON_EDGE_INTEGRATIONS_FILE ), [], PANTHEON_EDGE_INTEGRATIONS_VERSION, true );
 	}
 }
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -46,8 +46,7 @@ function enqueue_script() {
 
 	// Enqueue the script anytime we're not in the admin.
 	if ( ! is_admin() ) {
-		$path = ! empty( $suffix ) ? "/dist/js/assets$suffix.js" : '/assets/js/assets.js';
-		wp_enqueue_script( 'pantheon-ei', plugins_url( $path, PANTHEON_EDGE_INTEGRATIONS_FILE ), [], PANTHEON_EDGE_INTEGRATIONS_VERSION, true );
+		wp_enqueue_script( 'pantheon-ei', plugins_url( '/dist/js/assets' . $suffix . '.js', PANTHEON_EDGE_INTEGRATIONS_FILE ), [], PANTHEON_EDGE_INTEGRATIONS_VERSION, true );
 	}
 }
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -51,6 +51,7 @@ function enqueue_script() {
 
 		/**
 		 * Allow developers to hook in after the pantheon-ei script is enqueued.
+		 *
 		 * @todo Write documentation for this hook.
 		 * @hook pantheon.ei.enqueue_script
 		 * @param string $plugin_version The plugin version.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -52,7 +52,6 @@ function enqueue_script() {
 		/**
 		 * Allow developers to hook in after the pantheon-ei script is enqueued.
 		 *
-		 * @todo Write documentation for this hook.
 		 * @hook pantheon.ei.enqueue_script
 		 * @param string $plugin_version The plugin version.
 		 * @param string $plugin_file The plugin file path.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -25,8 +25,9 @@ function bootstrap() {
 	$plugin_version = $plugin_data['Version'];
 	define( 'PANTHEON_EDGE_INTEGRATIONS_VERSION', $plugin_version );
 
-	// Load the Interest namespace.
+	// Load Interests and Analytics.
 	Interest\bootstrap();
+	Analytics\bootstrap();
 
 	// Set the Vary headers.
 	add_action( 'init', $n( 'set_vary_headers' ) );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -32,7 +32,7 @@ function bootstrap() {
 	add_action( 'init', $n( 'set_vary_headers' ) );
 
 	// Enqueue the script.
-	add_action( 'wp_enqueue_scripts', $n( 'register_script' ) );
+	add_action( 'wp_enqueue_scripts', $n( 'enqueue_script' ) );
 }
 
 /**
@@ -40,7 +40,7 @@ function bootstrap() {
  *
  * @return void
  */
-function register_script() {
+function enqueue_script() {
 	/* Use minified libraries if SCRIPT_DEBUG is turned off. */
 	$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 


### PR DESCRIPTION
There's a lot here, y'all. This is a biggie.

The key concept of this PR is to natively integrate with Google Analytics and Google Tag Manager. To support this, a new `analytics.php` namespace is created as well as a `gtm-headers.js` file similar to the [`gtm_headers.js`](https://github.com/pantheon-systems/smart_content_cdn/blob/main/js/gtm_headers.js) file in [Smart Content CDN](https://github.com/pantheon-systems/smart_content_cdn). The analytics code:

* adds the code block that should appear in the HTML `<head>`
* adds the code block that should appear in the HTML `<body>`
* passes variables in PHP to the javascript object
* adds a function -- `Analytics\get_gtm_code` which returns the GTM code, if one is set
* adds a filter that allows the GTM code to be set programmatically. If set via the filter, this is returned in `get_gtm_code`
* adds a setting where GTM code can be added in the General Settings page in the admin
  * if the GTM code was added via the filter, this option does not appear
  * this option can also be overridden by passing `__return_true` to the filter if you want to use another method of defining the GTM code (e.g. you have another analytics plugin that you use that adds the GTM tags)
* adds a sanitization callback for the option to ensure that the GTM code contains `GTM` -- no other codes are supported (e.g. `G-` or `UA-` codes)
* applies the filter to the `get_gtm_code` function if the GTM code was set via the option

Additionally, because we're adding a new javascript file, consideration needed to be made to handle multiple javascript imports. For this, the PR:

* moves the register script function into the main `namespace.php` and renames to `enqueue_script`
* repurposes the register script function in `interests.php` to just localize the compiled javascript file, passing values if we have them
* adds an action that fires immediately after the javascript file is enqueued, so the localize functions do not fire before the script is enqueued, and so other functions can hook after the js file is enqueued 
* renames the localization object name to `eiInterest` from `pantheon_ei`

**Follow on work:**
- [x] Write documentation for `pantheon.ei.after_enqueue_script` hook (to be completed as part of EI-93)
- [x] Write documentation for `pantheon.ei.gtm_code` filter (to be completed as part of EI-93)
- [x] Consider rewriting `interest-count.js` to use a `Pantheon` object into which all the functions are saved (e.g. align with code style of `gtm-headers.js`) (Ticket created, [EI-108](https://getpantheon.atlassian.net/browse/EI-108))
- [ ] Release an update of Pantheon WordPress Edge Integrations plugin
- [ ] Update wp13n and test GA/GTM