### PR TITLE
bump versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pantheon WordPress Edge Integrations
 
-Stable tag: 0.2.10  
+Stable tag: 0.2.11  
 Requires at least: 5.8  
 Tested up to: 5.9  
 Requires PHP: 7.4  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pantheon-wordpress-edge-integrations",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "WordPress plugin to support Pantheon Edge Integrations and personalization features",
   "scripts": {
     "bump:patch": "bump patch --commit 'Version %s.' pantheon-wordpress-edge-integrations.php README.md",

--- a/pantheon-wordpress-edge-integrations.php
+++ b/pantheon-wordpress-edge-integrations.php
@@ -4,7 +4,7 @@
  * Description: WordPress plugin to support Pantheon Edge Integrations and personalization features.
  * Author: Pantheon
  * Author URI: https://pantheon.io
- * Version: 0.2.11-dev
+ * Version: 0.2.12-dev
  *
  * @package Pantheon/EdgeIntegrations
  */


### PR DESCRIPTION
This bumps the plugin version to 0.2.12-dev and 0.2.12 in `package.json`. Bumps stable tag in readme to 0.2.11.