### PR TITLE
[EI-52] fix hook points

### DIFF
--- a/inc/interest.php
+++ b/inc/interest.php
@@ -50,11 +50,7 @@ function localize_script() {
 			 * @hook pantheon.ei.localized_terms
 			 * @param array Terms to localize.
 			 */
-			'post_terms' => apply_filters( 'pantheon.ei.localized_terms', $post_terms ),
-			'interest_threshold' => get_interest_threshold(),
-			'cookie_expiration' => get_cookie_expiration(),
-		]
-	);
+	wp_localize_script( 'pantheon-ei', 'eiInterest', $localized_obj );
 }
 
 /**

--- a/inc/interest.php
+++ b/inc/interest.php
@@ -40,16 +40,16 @@ function localize_script() {
 	$taxonomy = get_interest_taxonomy();
 	$post_terms = wp_get_post_terms( $post_id, $taxonomy, [ 'fields' => 'slugs' ] ) ?: [];
 
-	wp_localize_script(
-		'pantheon-ei',
-		'eiInterest',
-		[
-			/**
-			 * Allow engineers to modify terms before they are localized.
-			 *
-			 * @hook pantheon.ei.localized_terms
-			 * @param array Terms to localize.
-			 */
+	if ( in_array( $post->post_type, get_interest_allowed_post_types(), true ) ) {
+		/**
+		 * Allow engineers to modify terms before they are localized.
+		 *
+		 * @hook pantheon.ei.localized_terms
+		 * @param array Terms to localize.
+		 */
+		$localized_obj['post_terms'] = apply_filters( 'pantheon.ei.localized_terms', $post_terms );
+	}
+
 	wp_localize_script( 'pantheon-ei', 'eiInterest', $localized_obj );
 }
 

--- a/inc/interest.php
+++ b/inc/interest.php
@@ -29,6 +29,13 @@ function bootstrap() {
  */
 function localize_script() {
 	global $post;
+
+	$localized_obj = [
+		'post_terms' => [],
+		'interest_threshold' => get_interest_threshold(),
+		'cookie_expiration' => get_cookie_expiration(),
+	];
+
 	$post_id = $post->ID;
 	$taxonomy = get_interest_taxonomy();
 	$post_terms = wp_get_post_terms( $post_id, $taxonomy, [ 'fields' => 'slugs' ] ) ?: [];

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -85,9 +85,12 @@ function get_supported_vary_headers() : array {
 	] );
 
 	// Omit headers that are not supported.
-	$key = array_search( false, $defaults, true );
-	if ( false !== $defaults ) {
-		unset( $defaults[ $key ] );
+	if ( ! is_bool( $defaults ) ) {
+		foreach ( $defaults as $key => $value ) {
+			if ( $value === false ) {
+				unset( $defaults[ $key ] );
+			}
+		}
 	}
 
 	// Return the modified array of supported vary header keys.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -32,7 +32,7 @@ function bootstrap() {
 	Analytics\bootstrap();
 
 	// Set the Vary headers.
-	add_action( 'init', $n( 'set_vary_headers' ) );
+	add_action( 'init', $n( 'set_vary_headers' ), 999 );
 
 	// Enqueue the script.
 	add_action( 'wp_enqueue_scripts', $n( 'enqueue_script' ) );


### PR DESCRIPTION
There are a couple hook points where things were not being set or filtered correctly. This PR should take care of them. This is a continuation of https://github.com/pantheon-systems/pantheon-edge-integrations-consent-management/pull/17

* Sets the vary headers very late, allowing other plugins to hook in and filter the supported headers earlier.
* fixes the array of supported vary headers
* does not set any post terms if the post type is not supported