### PR TITLE
[EI-111] Edge Integrations enabled function

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -128,3 +128,28 @@ function update_vary_headers( array $key = null, array $data = null ) : array {
 
 	return $vary_header;
 }
+
+/**
+ * Check if Edge Integrations have been configured.
+ *
+ * Validates header data for any supported vary headers, including those that have been added later.
+ *
+ * @return bool Whether Edge Integrations have been configured and the CDN is returning data.
+ */
+function edge_integrations_enabled() : bool {
+	// Get the software-supported headers.
+	$headers = get_supported_vary_headers();
+	$enabled_headers = [];
+
+	// Loop through the headers and see if we've got data.
+	foreach ( $headers as $header ) {
+		$data = EI\HeaderData::header( $header );
+
+		if ( ! empty( $data ) ) {
+			$enabled_headers[] = $header;
+		}
+	}
+
+	// If enabled_headers is not empty, edge integrations are enabled.
+	return apply_filters( 'pantheon.ei.enabled', ! empty( $enabled_headers ) );
+}

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -65,4 +65,36 @@ class testsBase extends TestCase {
 			'Data does not match'
 		);
 	}
+
+	/**
+	 * Test the edge_integrations_enabled function.
+	 */
+	public function testEIEnabled() {
+		$headers = get_supported_vary_headers();
+		$enabled_headers = [];
+
+		foreach ( $headers as $header ) {
+			$data = EI\HeaderData::header( $header );
+
+			if ( $data ) {
+				$enabled_headers[] = $header;
+			}
+		}
+
+		// If $enabled_headers is empty, edge_integrations_enabled should return false.
+		if ( empty( $enabled_headers ) ) {
+			$this->assertFalse( edge_integrations_enabled() );
+		} else {
+			$this->assertTrue( edge_integrations_enabled() );
+		}
+
+		// Force true or false with the filter.
+		add_filter( 'pantheon.ei.enabled', '__return_true' );
+		$this->assertTrue( edge_integrations_enabled() );
+		remove_filter( 'pantheon.ei.enabled', '__return_true' );
+
+		add_filter( 'pantheon.ei.enabled', '__return_false' );
+		$this->assertFalse( edge_integrations_enabled() );
+		remove_filter( 'pantheon.ei.enabled', '__return_false' );
+	}
 }


### PR DESCRIPTION
This PR adds a new `edge_integrations_enabled` function that checks that we have header data for any of the enabled vary headers.