### PR TITLE
add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners. See:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @pantheon-systems/edge-integrations


### PR DESCRIPTION
This PR adds a CODEOWNERS file for the Pantheon WordPress Edge Integrations plugin repository.