### PR TITLE
[EI-110] Wider edge_integrations_enabled checks

### DIFF
--- a/inc/geo.php
+++ b/inc/geo.php
@@ -51,7 +51,7 @@ function get_geo( string $data_type = '', $data = null, string $header = 'Audien
 	$parsed_geo = apply_filters( 'pantheon.ei.parsed_geo_data', EI\HeaderData::parse( $header, $data ) );
 	// If no geo data type was passed, return all Audience data.
 	if ( empty( $data_type ) ) {
-		return json_encode( $parsed_geo );
+		return ! empty( $parsed_geo ) ? json_encode( $parsed_geo ) : '';
 	}
 
 	// If no data exists for the data type, return an empty string.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -187,7 +187,7 @@ function edge_integrations_enabled() : bool {
 	 *
 	 * @param string $custom_headers Custom headers added by third-party code.
 	 */
-	$custom_headers = apply_filters( 'pantheon.ei.get_custom_headers', '__return_empty_string' );
+	$custom_headers = apply_filters( 'pantheon.ei.get_custom_headers', '' );
 
 	// Check if we have geo or interest headers.
 	if (

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -190,15 +190,8 @@ function edge_integrations_enabled() : bool {
 
 	// Check any other headers that might have been set.
 	if ( ! $edge_enabled ) {
-		/**
-		 * Allow developers to add their own checks for Edge Integrations headers.
-		 *
-		 * If custom headers are being used, they should be passed into this filter so the edge_integrations_enabled() check can recognize them.
-		 * It is expectedt that the custom code has a function similar to get_geo and get_interest that returns the headers, and that this function uses this filter.
-		 *
-		 * @param string $custom_headers Custom headers added by third-party code.
-		 */
-		$custom_headers = apply_filters( 'pantheon.ei.get_custom_headers', '' );
+		// Get the custom header data, if it's been set.
+		$custom_headers = apply_filters( 'pantheon.ei.custom_header_data', '' );
 
 		// Get the software-supported headers.
 		$headers = get_supported_vary_headers();

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -179,27 +179,27 @@ function edge_integrations_enabled() : bool {
 	$edge_enabled = false;
 	$geo = Geo\get_geo();
 	$interest = Interest\get_interest();
-	/**
-	 * Allow developers to add their own checks for Edge Integrations headers.
-	 *
-	 * If custom headers are being used, they should be passed into this filter so the edge_integrations_enabled() check can recognize them.
-	 * It is expectedt that the custom code has a function similar to get_geo and get_interest that returns the headers, and that this function uses this filter.
-	 *
-	 * @param string $custom_headers Custom headers added by third-party code.
-	 */
-	$custom_headers = apply_filters( 'pantheon.ei.get_custom_headers', '' );
 
 	// Check if we have geo or interest headers.
 	if (
 		! empty( $geo ) ||
-		! empty( $interest ) ||
-		! empty( $custom_headers )
+		! empty( $interest )
 	) {
 		$edge_enabled = true;
 	}
 
 	// Check any other headers that might have been set.
 	if ( ! $edge_enabled ) {
+		/**
+		 * Allow developers to add their own checks for Edge Integrations headers.
+		 *
+		 * If custom headers are being used, they should be passed into this filter so the edge_integrations_enabled() check can recognize them.
+		 * It is expectedt that the custom code has a function similar to get_geo and get_interest that returns the headers, and that this function uses this filter.
+		 *
+		 * @param string $custom_headers Custom headers added by third-party code.
+		 */
+		$custom_headers = apply_filters( 'pantheon.ei.get_custom_headers', '' );
+
 		// Get the software-supported headers.
 		$headers = get_supported_vary_headers();
 		$enabled_headers = [];
@@ -213,7 +213,8 @@ function edge_integrations_enabled() : bool {
 			}
 		}
 
-		if ( ! empty( $enabled_headers ) ) {
+		// Check if custom headers were set AND they are not empty.
+		if ( ! empty( $custom_headers ) && ! empty( $enabled_headers ) ) {
 			$edge_enabled = true;
 		}
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -176,16 +176,35 @@ function update_vary_headers( array $key = null, array $data = null ) : array {
  * @return bool Whether Edge Integrations have been configured and the CDN is returning data.
  */
 function edge_integrations_enabled() : bool {
-	// Get the software-supported headers.
-	$headers = get_supported_vary_headers();
-	$enabled_headers = [];
+	$edge_enabled = false;
+	$geo = Geo\get_geo();
+	$interest = Interest\get_interest();
 
-	// Loop through the headers and see if we've got data.
-	foreach ( $headers as $header ) {
-		$data = EI\HeaderData::header( $header );
+	// Check if we have geo or interest headers.
+	if (
+		! empty( $geo ) ||
+		! empty( $interest )
+	) {
+		$edge_enabled = true;
+	}
 
-		if ( ! empty( $data ) ) {
-			$enabled_headers[] = $header;
+	// Check any other headers that might have been set.
+	if ( ! $edge_enabled ) {
+		// Get the software-supported headers.
+		$headers = get_supported_vary_headers();
+		$enabled_headers = [];
+
+		// Loop through the headers and see if we've got data.
+		foreach ( $headers as $header ) {
+			$data = EI\HeaderData::header( $header );
+
+			if ( ! empty( $data ) ) {
+				$enabled_headers[] = $header;
+			}
+		}
+
+		if ( ! empty( $enabled_headers ) ) {
+			$edge_enabled = true;
 		}
 	}
 
@@ -198,5 +217,5 @@ function edge_integrations_enabled() : bool {
 	 *
 	 * @param bool $enabled Whether Edge Integrations have been configured and the CDN is returning data.
 	 */
-	return apply_filters( 'pantheon.ei.enabled', ! empty( $enabled_headers ) );
+	return apply_filters( 'pantheon.ei.enabled', $edge_enabled );
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -179,11 +179,21 @@ function edge_integrations_enabled() : bool {
 	$edge_enabled = false;
 	$geo = Geo\get_geo();
 	$interest = Interest\get_interest();
+	/**
+	 * Allow developers to add their own checks for Edge Integrations headers.
+	 *
+	 * If custom headers are being used, they should be passed into this filter so the edge_integrations_enabled() check can recognize them.
+	 * It is expectedt that the custom code has a function similar to get_geo and get_interest that returns the headers, and that this function uses this filter.
+	 *
+	 * @param string $custom_headers Custom headers added by third-party code.
+	 */
+	$custom_headers = apply_filters( 'pantheon.ei.get_custom_headers', '__return_empty_string' );
 
 	// Check if we have geo or interest headers.
 	if (
 		! empty( $geo ) ||
-		! empty( $interest )
+		! empty( $interest ) ||
+		! empty( $custom_headers )
 	) {
 		$edge_enabled = true;
 	}

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -116,7 +116,7 @@ class testsBase extends TestCase {
 
 		// Test edge_ingegrations_enabled by passing in interest data.
 		add_filter( 'pantheon.ei.parsed_interest_data', function( $data ) {
-			return 'interest';
+			return ['interest'];
 		} );
 		$this->assertTrue( edge_integrations_enabled() );
 		remove_all_filters( 'pantheon.ei.parsed_interest_data' );

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -96,5 +96,29 @@ class testsBase extends TestCase {
 		add_filter( 'pantheon.ei.enabled', '__return_false' );
 		$this->assertFalse( edge_integrations_enabled() );
 		remove_filter( 'pantheon.ei.enabled', '__return_false' );
+
+		// Test edge_integrations_enabled by passing in geo data.
+		remove_all_filters( 'pantheon.ei.parsed_geo_data' );
+		$dummy_data = [
+			'city' => 'City',
+			'region' => 'State',
+			'country' => 'US',
+		];
+		add_filter( 'pantheon.ei.parsed_geo_data', function( $data ) use ( $dummy_data ) {
+			$data['city'] = $dummy_data['city'];
+			$data['region'] = $dummy_data['region'];
+			$data['country'] = $dummy_data['country'];
+			return $data;
+		} );
+		$this->assertTrue( edge_integrations_enabled() );
+		remove_all_filters( 'pantheon.ei.parsed_geo_data' );
+
+		// Test edge_ingegrations_enabled by passing in interest data.
+		remove_all_filters( 'pantheon.ei.parsed_interest_data' );
+		add_filter( 'pantheon.ei.parsed_interest_data', function( $data ) {
+			return 'interest';
+		} );
+		$this->assertTrue( edge_integrations_enabled() );
+		remove_all_filters( 'pantheon.ei.parsed_interest_data' );
 	}
 }

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -70,6 +70,8 @@ class testsBase extends TestCase {
 	 * Test the edge_integrations_enabled function.
 	 */
 	public function testEIEnabled() {
+		remove_all_filters( 'pantheon.ei.parsed_geo_data' );
+		remove_all_filters( 'pantheon.ei.parsed_interest_data' );
 		$headers = get_supported_vary_headers();
 		$enabled_headers = [];
 
@@ -98,7 +100,6 @@ class testsBase extends TestCase {
 		remove_filter( 'pantheon.ei.enabled', '__return_false' );
 
 		// Test edge_integrations_enabled by passing in geo data.
-		remove_all_filters( 'pantheon.ei.parsed_geo_data' );
 		$dummy_data = [
 			'city' => 'City',
 			'region' => 'State',
@@ -114,7 +115,6 @@ class testsBase extends TestCase {
 		remove_all_filters( 'pantheon.ei.parsed_geo_data' );
 
 		// Test edge_ingegrations_enabled by passing in interest data.
-		remove_all_filters( 'pantheon.ei.parsed_interest_data' );
 		add_filter( 'pantheon.ei.parsed_interest_data', function( $data ) {
 			return 'interest';
 		} );

--- a/tests/geoTest.php
+++ b/tests/geoTest.php
@@ -9,8 +9,6 @@ use Pantheon\EI;
 use Pantheon\EI\WP\Geo;
 use PHPUnit\Framework\TestCase;
 
-use function Pantheon\EI\WP\Geo\get_geo_allowed_values;
-
 /**
  * Main test class for WordPress Edge Integrations plugin.
  */
@@ -33,6 +31,7 @@ class geoTests extends TestCase {
 	 * @group wp-geo
 	 */
 	public function testGetGeo( array $audience_data ) {
+		remove_all_filters( 'pantheon.ei.parsed_geo_data' );
 		// Get the actual data in a format that's easier to read.
 		$parsed_data = EI\HeaderData::parse( 'Audience-Set', $audience_data );
 		// Get the geo country.
@@ -178,7 +177,7 @@ class geoTests extends TestCase {
 	 * Test the pantheon.ei.geo_allowed_values filter and get_geo_allowed_values function.
 	 */
 	public function testGeoAllowedValues() {
-		$allowed_values = get_geo_allowed_values();
+		$allowed_values = Geo\get_geo_allowed_values();
 		$this->assertIsArray( $allowed_values );
 		$this->assertNotEmpty( $allowed_values );
 		$this->assertEquals(
@@ -205,7 +204,7 @@ class geoTests extends TestCase {
 		}, 10, 1 );
 
 		// Validate that the new value is in the allowed values.
-		$this->assertContains( 'some-other-value', get_geo_allowed_values() );
+		$this->assertContains( 'some-other-value', Geo\get_geo_allowed_values() );
 	}
 
 	/**

--- a/tests/interestTest.php
+++ b/tests/interestTest.php
@@ -58,7 +58,7 @@ class interestsTests extends TestCase {
 	 * Test Cookie expiration.
 	 */
 	public function testCookieExpiration() {
-		$this->assertTrue( 
+		$this->assertTrue(
 			function_exists( '\\Pantheon\\EI\\WP\\Interest\\get_cookie_expiration' ),
 			'get_cookie_expiration function does not exist'
 		);
@@ -179,6 +179,7 @@ class interestsTests extends TestCase {
 	 * @group wp-interest
 	 */
 	public function testParsedInterestData() {
+		remove_all_filters( 'pantheon.ei.parsed_interest_data' );
 		$input = [ 'HTTP_INTEREST' =>'Carl Sagan|Richard Feynman|Albert Einstein' ];
 		// Filter the parsed interest data.
 		add_filter( 'pantheon.ei.parsed_interest_data', function( $interest_data ) {


### PR DESCRIPTION
The `edge_integrations_enabled` check checks headers sent, but if we aren't sending headers (like we are in the admin) then this will return false. 

This PR checks returned geo and interest headers first, then checks the headers that are sent (and if they get data back).

In most cases, checking sent headers and their returned responses will not be checked, as we skip it if we have geo or interest headers. However, if custom headers were sent, these will be checked after geo and interest. This is resolved by the addition of a new filter, `pantheon.ei.get_custom_headers` which should be used in a third-party function that returns the custom header data (similar to `Geo\get_geo` and `Interest\get_interest`) which will hook the third party code into `edge_integrations_enabled`.